### PR TITLE
Throw exception when URDF has free-floating joints

### DIFF
--- a/src/urdf/parser.cc
+++ b/src/urdf/parser.cc
@@ -426,7 +426,7 @@ namespace hpp
 				    it->second->limits);
 	    break;
 	  case ::urdf::Joint::FLOATING:
-	    createFreeflyerJoint (jointName, position);
+	    throw std::runtime_error ("FLOATING joints are not supported");
 	    break;
 	  case ::urdf::Joint::PLANAR:
 	    throw std::runtime_error ("PLANAR joints are not supported");


### PR DESCRIPTION
Partially solves #5 
